### PR TITLE
Additional Options

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,6 +1,19 @@
+.app {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+
+.content {
+  flex-grow: 1;
+  margin: 0px;
+  resize: none;
+}
+
 .mat-card-content {
   display: flex;
   flex-direction: row;
+  height: 100%;
   padding: 0.5rem;
 }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,9 +1,11 @@
 <router-outlet></router-outlet>
-<h2>OpenBabel Web UI</h2>
-<mat-card>
-  <mat-card-content>
-    <app-input class="inputComponent"></app-input>
-    <app-options class="optionsComponent"></app-options>
-    <app-output class="outputComponent"></app-output>
-  </mat-card-content>
-</mat-card>
+<div class="app">
+  <h2>OpenBabel Web UI</h2>
+  <mat-card class="content">
+    <mat-card-content>
+      <app-input class="inputComponent"></app-input>
+      <app-options class="optionsComponent"></app-options>
+      <app-output class="outputComponent"></app-output>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/src/app/input/input.component.css
+++ b/src/app/input/input.component.css
@@ -1,6 +1,13 @@
-.inputTextBox {
+mat-card {
+  box-sizing: border-box;
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+
+mat-card .inputTextBox {
   flex-grow: 1;
-	overflow-x: scroll;
+  overflow-x: scroll;
   overflow-wrap: normal;
   resize: horizontal;
   width: 100%;

--- a/src/app/input/input.component.css
+++ b/src/app/input/input.component.css
@@ -1,11 +1,13 @@
-mat-card {
+.mat-card {
   box-sizing: border-box;
   display: flex;
   flex-flow: column;
   height: 100%;
 }
 
-mat-card .inputTextBox {
+.mat-card .inputTextBox {
+  background: rgb(200, 200, 200);
+  color: black;
   flex-grow: 1;
   overflow-x: scroll;
   overflow-wrap: normal;

--- a/src/app/options/options.component.css
+++ b/src/app/options/options.component.css
@@ -17,7 +17,9 @@
 }
 
 .mat-card .additionalOptions {
-  flex-grow: 1;
+  background: rgb(200, 200, 200);
+  color: black;
+  height: 3em;
   resize: none;
   width: 100%;
 }

--- a/src/app/options/options.component.css
+++ b/src/app/options/options.component.css
@@ -1,9 +1,27 @@
-mat-card-title {
+.mat-card {
+  box-sizing: border-box;
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+
+.mat-card-title {
   text-align: center;
 }
-mat-form-field {
+
+.mat-form-field {
   box-sizing: border-box;
   margin: 0;
   max-width: 100%;
   width: 100%;
+}
+
+.mat-card .additionalOptions {
+  flex-grow: 1;
+  resize: none;
+  width: 100%;
+}
+
+.spacer {
+  height: 2rem;
 }

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -41,5 +41,5 @@
   </mat-form-field>
   <div class="spacer"></div>
   <div>Additional Options</div>
-  <textarea class="additionalOptions" [(ngModel)]="additionalOptions"></textarea>
+  <textarea matInput class="additionalOptions" [(ngModel)]="additionalOptions"></textarea>
 </mat-card>

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -10,6 +10,7 @@
       aria-label="Input Format"
       [formControl]="inputControl"
       [matAutocomplete]="inputAutocomplete"
+      [(ngModel)]="inputFormat"
       required>
     <mat-error *ngIf="inputControl.invalid">Must choose a valid input format</mat-error>
     <mat-autocomplete class="inputAutocomplete" #inputAutocomplete autoActiveFirstOption panelWidth="auto">
@@ -29,6 +30,7 @@
       aria-label="Output Format"
       [formControl]="outputControl"
       [matAutocomplete]="outputAutocomplete"
+      [(ngModel)]="outputFormat"
       required>
     <mat-error *ngIf="outputControl.invalid">Must choose a valid output format</mat-error>
     <mat-autocomplete class="outputAutocomplete" #outputAutocomplete autoActiveFirstOption panelWidth="auto">

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -13,7 +13,7 @@
       [(ngModel)]="inputFormat"
       required>
     <mat-error *ngIf="inputControl.invalid">Must choose a valid input format</mat-error>
-    <mat-autocomplete class="inputAutocomplete" #inputAutocomplete autoActiveFirstOption panelWidth="auto">
+    <mat-autocomplete class="inputAutocomplete" #inputAutocomplete autoActiveFirstOption>
       <mat-option *ngFor="let format of inputList | async" [value]="format">
         {{format}}
       </mat-option>

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -17,7 +17,8 @@
         {{format}}
       </mat-option>
     </mat-autocomplete>
-  </mat-form-field><br>
+  </mat-form-field>
+  <div class="spacer"></div>
   <mat-form-field class="outputFormat">
     <mat-label>Output Format</mat-label>
     <input
@@ -36,4 +37,7 @@
       </mat-option>
     </mat-autocomplete>
   </mat-form-field>
+  <div class="spacer"></div>
+  <div>Additional Options</div>
+  <textarea class="additionalOptions" [(ngModel)]="additionalOptions"></textarea>
 </mat-card>

--- a/src/app/options/options.component.spec.ts
+++ b/src/app/options/options.component.spec.ts
@@ -86,4 +86,15 @@ describe('OptionsComponent', () => {
     expect(options.length).toEqual(1);
     expect((await options[0].getText())).toEqual("test1");
   });
+
+  it('should update additional options string from text in additional options textbox', async () => {
+    await fixture.whenStable();
+    const additionalOptionsTextBox = fixture.debugElement.query(By.css('.additionalOptions')).nativeElement;
+
+    additionalOptionsTextBox.value = "Additional options text";
+    additionalOptionsTextBox.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(component.additionalOptions).toEqual("Additional options text");
+  });
 });

--- a/src/app/options/options.component.spec.ts
+++ b/src/app/options/options.component.spec.ts
@@ -89,12 +89,11 @@ describe('OptionsComponent', () => {
 
   it('should update additional options string from text in additional options textbox', async () => {
     await fixture.whenStable();
-    const additionalOptionsTextBox = fixture.debugElement.query(By.css('.additionalOptions')).nativeElement;
+    const additionalOptionsHarness = await loader.getHarness(MatInputHarness.with(
+      {selector: '.additionalOptions'}));
 
-    additionalOptionsTextBox.value = "Additional options text";
-    additionalOptionsTextBox.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
+    await additionalOptionsHarness.setValue("Some additional options text");
 
-    expect(component.additionalOptions).toEqual("Additional options text");
+    expect(component.additionalOptions).toEqual("Some additional options text");
   });
 });

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -12,6 +12,7 @@ import { FORMATS } from '../formatlist';
 export class OptionsComponent implements OnInit {
   formats: String[] = FORMATS;
   inputControl = new FormControl('', [Validators.required, validateFormat]);
+  inputFormat: string = "";
   inputList: Observable<String[]> = this.inputControl.valueChanges.pipe(
     startWith(""),
     map(value => {
@@ -22,6 +23,7 @@ export class OptionsComponent implements OnInit {
     })
   );
   outputControl = new FormControl('', [Validators.required, validateFormat]);
+  outputFormat: string = "";
   outputList: Observable<String[]> = this.outputControl.valueChanges.pipe(
     startWith(""),
     map(value => {
@@ -36,6 +38,10 @@ export class OptionsComponent implements OnInit {
   constructor() {}
 
   ngOnInit(): void {}
+
+  obabelOptionsString(): string {
+    return "-i" + this.inputFormat + " -o" + this.outputFormat + " " + this.additionalOptions;
+  }
 
 }
 

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -31,6 +31,7 @@ export class OptionsComponent implements OnInit {
       });
     }),
   );
+  additionalOptions: string = "";
 
   constructor() {}
 

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -38,11 +38,6 @@ export class OptionsComponent implements OnInit {
   constructor() {}
 
   ngOnInit(): void {}
-
-  obabelOptionsString(): string {
-    return "-i" + this.inputFormat + " -o" + this.outputFormat + " " + this.additionalOptions;
-  }
-
 }
 
 function validateFormat(control: AbstractControl): {[key: string]: any} | null {

--- a/src/app/output/output.component.css
+++ b/src/app/output/output.component.css
@@ -1,11 +1,13 @@
-mat-card {
+.mat-card {
   box-sizing: border-box;
   display: flex;
   flex-flow: column;
   height: 100%;
 }
 
-mat-card .outputTextBox {
+.mat-card .outputTextBox {
+  background: rgb(200, 200, 200);
+  color: black;
   flex-grow: 1;
   overflow-x: scroll;
   overflow-wrap: normal;

--- a/src/app/output/output.component.css
+++ b/src/app/output/output.component.css
@@ -1,6 +1,13 @@
-.outputTextBox {
+mat-card {
+  box-sizing: border-box;
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+
+mat-card .outputTextBox {
   flex-grow: 1;
-	overflow-x: scroll;
+  overflow-x: scroll;
   overflow-wrap: normal;
   resize: horizontal;
   width: 100%;


### PR DESCRIPTION
Added the additional options textbox.
Added the additional options textbox as another textarea. This required proper vertical spacing so it would be the same height as the input and output textareas. Also disabled vertical resizing on the input / output textareas and disabled their line wrapping. This PR also includes a function to obtain a string representing obabel input, although this function may change when how I need to use computeEngine is better understood.
This version can be accessed [here](https://20220126t152556-dot-personal-fa-starter-app.wl.r.appspot.com/client/).

![image](https://user-images.githubusercontent.com/93948143/151248745-cef3cd8e-b5db-44fa-9a79-ba42338fcf10.png)

Unit tests:
![image](https://user-images.githubusercontent.com/93948143/151007769-0a267831-0fb7-4aab-94b6-01912304dd5e.png)
