### PR TITLE
Submit

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,8 @@ import { AppComponent } from './app.component';
 import { InputComponent } from './input/input.component';
 import { OutputComponent } from './output/output.component';
 import { OptionsComponent } from './options/options.component';
+import { DataService } from './submit.abstract.service';
+import { SubmitService } from './submit.service';
 
 @NgModule({
   declarations: [AppComponent, InputComponent, OutputComponent, OptionsComponent],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HttpClient } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from './material/material.module';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
@@ -16,6 +16,7 @@ import { OutputComponent } from './output/output.component';
 import { OptionsComponent } from './options/options.component';
 import { DataService } from './submit.abstract.service';
 import { SubmitService } from './submit.service';
+import { MockSubmitService } from './submit.mock.service';
 
 @NgModule({
   declarations: [AppComponent, InputComponent, OutputComponent, OptionsComponent],
@@ -35,6 +36,13 @@ import { SubmitService } from './submit.service';
     {
       provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
       useValue: { appearance: 'fill' },
+    },
+    {
+      provide: DataService,
+      deps: [HttpClient],
+      useFactory: (http: HttpClient) => {
+        return new SubmitService(http);
+      },
     },
   ],
   bootstrap: [AppComponent],

--- a/src/app/input/input.component.html
+++ b/src/app/input/input.component.html
@@ -1,4 +1,4 @@
-<mat-card *ngIf="data$ | async as data">
+<mat-card *ngIf="service.data$ | async as data">
   <mat-card-title>Input</mat-card-title>
   <textarea matInput class="inputTextBox" [(ngModel)]="data.inputString"></textarea>
 </mat-card>

--- a/src/app/input/input.component.spec.ts
+++ b/src/app/input/input.component.spec.ts
@@ -43,13 +43,13 @@ describe('InputComponent', () => {
     await fixture.whenStable();
     const inputHarness = await loader.getHarness(MatInputHarness.with(
       {selector: '.inputTextBox'}));
-    component.data$.subscribe(
+    component.service.data$.subscribe(
       data => expect(data['inputString']).toEqual("")
     );
 
     await inputHarness.setValue("Some input text");
 
-    component.data$.subscribe(
+    component.service.data$.subscribe(
       data => expect(data['inputString']).toEqual("Some input text")
     );
   });

--- a/src/app/input/input.component.spec.ts
+++ b/src/app/input/input.component.spec.ts
@@ -11,11 +11,14 @@ import { tap } from 'rxjs/operators';
 
 import { OpenBabelData } from '../OpenBabelData';
 import { InputComponent } from './input.component';
+import { DataService } from '../submit.abstract.service';
+import { MockSubmitService } from '../submit.mock.service';
 
 describe('InputComponent', () => {
   let component: InputComponent;
   let fixture: ComponentFixture<InputComponent>;
   let loader: HarnessLoader;
+  let service: MockSubmitService;
   const blankData: OpenBabelData = {inputString: "",
     inputFormat: "", outputFormat: "", additionalOptions: ""};
 
@@ -24,11 +27,13 @@ describe('InputComponent', () => {
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
       imports: [ FormsModule, HttpClientTestingModule ],
       declarations: [ InputComponent ],
+      providers: [ InputComponent, { provide: DataService, useClass: MockSubmitService } ]
     })
     .compileComponents();
   });
 
   beforeEach(() => {
+    service = TestBed.inject(DataService);
     fixture = TestBed.createComponent(InputComponent);
     component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
@@ -43,13 +48,13 @@ describe('InputComponent', () => {
     await fixture.whenStable();
     const inputHarness = await loader.getHarness(MatInputHarness.with(
       {selector: '.inputTextBox'}));
-    component.service.data$.subscribe(
+    service.data$.subscribe(
       data => expect(data['inputString']).toEqual("")
     );
 
     await inputHarness.setValue("Some input text");
 
-    component.service.data$.subscribe(
+    service.data$.subscribe(
       data => expect(data['inputString']).toEqual("Some input text")
     );
   });

--- a/src/app/input/input.component.ts
+++ b/src/app/input/input.component.ts
@@ -10,7 +10,5 @@ import { SubmitService } from '../submit.service';
   styleUrls: ['./input.component.css']
 })
 export class InputComponent {
-  data$: Observable<OpenBabelData> = this.service.data$;
-
-  constructor(private readonly service: SubmitService) {}
+  constructor(readonly service: SubmitService) {}
 }

--- a/src/app/input/input.component.ts
+++ b/src/app/input/input.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { OpenBabelData } from '../OpenBabelData';
-import { SubmitService } from '../submit.service';
+import { DataService } from '../submit.abstract.service';
 
 @Component({
   selector: 'app-input',
@@ -10,5 +10,5 @@ import { SubmitService } from '../submit.service';
   styleUrls: ['./input.component.css']
 })
 export class InputComponent {
-  constructor(readonly service: SubmitService) {}
+  constructor(readonly service: DataService) {}
 }

--- a/src/app/options/options.component.css
+++ b/src/app/options/options.component.css
@@ -24,6 +24,11 @@
   width: 100%;
 }
 
+.mat-card .submit {
+  display: flex;
+  justify-content: right;
+}
+
 .spacer {
   height: 2rem;
 }

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -44,7 +44,7 @@
   <textarea matInput class="additionalOptions" [(ngModel)]="data.additionalOptions"></textarea>
   <div class="spacer"></div>
   <div class="submit">
-    <button mat-raised-button type="submit" #submitButton [disabled]="submit$ | async">
+    <button mat-raised-button class="submitButton" type="submit" #submitButton [disabled]="submit$ | async">
       Submit</button>
   </div>
 </mat-card>

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -1,4 +1,4 @@
-<mat-card *ngIf="data$ | async as data">
+<mat-card *ngIf="service.data$ | async as data">
   <mat-card-title>Options</mat-card-title>
   <mat-form-field class="inputFormat">
     <mat-label>Input Format</mat-label>

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -43,7 +43,7 @@
   <div>Additional Options</div>
   <textarea matInput class="additionalOptions" [(ngModel)]="data.additionalOptions"></textarea>
   <div class="spacer"></div>
-  <div class="submit">
-    <button mat-raised-button type="submit">Submit</button>
+  <div class="submit" #submit>
+    <button mat-raised-button type="submit" [disabled]="submit$ | async">Submit</button>
   </div>
 </mat-card>

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -12,7 +12,8 @@
       [matAutocomplete]="inputAutocomplete"
       [(ngModel)]="data.inputFormat"
       required>
-    <mat-error *ngIf="inputControl.invalid">Must choose a valid input format</mat-error>
+    <mat-error class="input-error" *ngIf="inputControl.invalid">
+      Must choose a valid input format</mat-error>
     <mat-autocomplete class="inputAutocomplete" #inputAutocomplete autoActiveFirstOption panelWidth="auto">
       <mat-option *ngFor="let format of inputList | async" [value]="format">
         {{format}}
@@ -32,7 +33,8 @@
       [matAutocomplete]="outputAutocomplete"
       [(ngModel)]="data.outputFormat"
       required>
-    <mat-error *ngIf="outputControl.invalid">Must choose a valid output format</mat-error>
+    <mat-error class="output-error" *ngIf="outputControl.invalid">
+      Must choose a valid output format</mat-error>
     <mat-autocomplete class="outputAutocomplete" #outputAutocomplete autoActiveFirstOption panelWidth="auto">
       <mat-option *ngFor="let format of outputList | async" [value]="format">
         {{format}}

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -47,6 +47,6 @@
   <div class="spacer"></div>
   <div class="submit">
     <button mat-raised-button class="submitButton" type="submit" #submitButton [disabled]=
-      "(submitting$ | async) || inputControl.invalid || outputControl.invalid">Submit</button>
+      "disabled$ | async">Submit</button>
   </div>
 </mat-card>

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -44,7 +44,7 @@
   <textarea matInput class="additionalOptions" [(ngModel)]="data.additionalOptions"></textarea>
   <div class="spacer"></div>
   <div class="submit">
-    <button mat-raised-button class="submitButton" type="submit" #submitButton [disabled]="submitting$ | async">
-      Submit</button>
+    <button mat-raised-button class="submitButton" type="submit" #submitButton [disabled]=
+      "(submitting$ | async) || inputControl.invalid || outputControl.invalid">Submit</button>
   </div>
 </mat-card>

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -43,7 +43,8 @@
   <div>Additional Options</div>
   <textarea matInput class="additionalOptions" [(ngModel)]="data.additionalOptions"></textarea>
   <div class="spacer"></div>
-  <div class="submit" #submit>
-    <button mat-raised-button type="submit" [disabled]="submit$ | async">Submit</button>
+  <div class="submit">
+    <button mat-raised-button type="submit" #submitButton [disabled]="submit$ | async">
+      Submit</button>
   </div>
 </mat-card>

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -42,4 +42,8 @@
   <div class="spacer"></div>
   <div>Additional Options</div>
   <textarea matInput class="additionalOptions" [(ngModel)]="data.additionalOptions"></textarea>
+  <div class="spacer"></div>
+  <div class="submit">
+    <button mat-raised-button type="submit">Submit</button>
+  </div>
 </mat-card>

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -44,7 +44,7 @@
   <textarea matInput class="additionalOptions" [(ngModel)]="data.additionalOptions"></textarea>
   <div class="spacer"></div>
   <div class="submit">
-    <button mat-raised-button class="submitButton" type="submit" #submitButton [disabled]="submit$ | async">
+    <button mat-raised-button class="submitButton" type="submit" #submitButton [disabled]="submitting$ | async">
       Submit</button>
   </div>
 </mat-card>

--- a/src/app/options/options.component.spec.ts
+++ b/src/app/options/options.component.spec.ts
@@ -106,19 +106,14 @@ describe('OptionsComponent', () => {
 
   it('should filter out write-only results from input drop-down list', async () => {
     await createState();
-    spyOn<any>(component, 'inputList').and.callFake(() => of([""]));
     const input = await loader.getHarness(MatAutocompleteHarness.with({
       selector: '.inputInput'}));
 
     await input.focus();
+    let options = await input.getOptions();
 
-    //expect(spy).toHaveBeenCalledWith("");
-    component.inputList.subscribe(
-      list => {
-        expect(list.length).toEqual(2);
-        expect(list[1]).toEqual("test2 [Read-only]");
-      }
-    );
+    expect(options.length).toEqual(2);
+    expect((await options[1].getText())).toEqual("test2 [Read-only]");
   });
 
   it('should filter results for input drowdown list based on input', async () => {
@@ -140,13 +135,10 @@ describe('OptionsComponent', () => {
       selector: '.outputInput'}));
 
     await output.focus();
+    let options = await output.getOptions();
 
-    component.outputList.subscribe(
-      list => {
-        expect(list.length).toEqual(2);
-        expect(list[1]).toEqual("test3 [Write-only]");
-      }
-    );
+    expect(options.length).toEqual(2);
+    expect(await options[1].getText()).toEqual("test3 [Write-only]");
   });
 
   it('should filter results for output drowdown list based on input', async () => {
@@ -200,17 +192,43 @@ describe('OptionsComponent', () => {
     expect(outputError).toBeNull();
   });
 
+  it('should update data$ observable from input in outputFormat box', async () => {
+    await createState();
+    const output = await loader.getHarness(MatAutocompleteHarness.with({
+      selector: '.outputInput'}));
+
+    await output.focus();
+    await output.enterText("Output format");
+
+    component.service.data$.subscribe(
+      data => expect(data['outputFormat']).toEqual("Output format")
+    );
+  });
+
+  it('should update data$ observable from input in inputFormat box', async () => {
+    await createState();
+    const input = await loader.getHarness(MatAutocompleteHarness.with({
+      selector: '.inputInput'}));
+
+    await input.focus();
+    await input.enterText("Input format");
+
+    component.service.data$.subscribe(
+      data => expect(data['inputFormat']).toEqual("Input format")
+    );
+  });
+
   it('should update data$ observable from additional options string', async () => {
     await createState();
     const additionalOptionsHarness = await loader.getHarness(MatInputHarness.with(
       {selector: '.additionalOptions'}));
 
-    component.data$.subscribe(
+    component.service.data$.subscribe(
       data => expect(data['additionalOptions']).toEqual("")
     );
     await additionalOptionsHarness.setValue("Some additional options text");
 
-    component.data$.subscribe(
+    component.service.data$.subscribe(
       data => expect(data['additionalOptions']).toEqual("Some additional options text")
     );
   });

--- a/src/app/options/options.component.spec.ts
+++ b/src/app/options/options.component.spec.ts
@@ -8,7 +8,6 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
-import { MatButtonHarness } from '@angular/material/button/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Observable, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -110,13 +109,10 @@ describe('OptionsComponent', () => {
   it('should call service.submit when submit button is pressed', async () => {
     await fixture.whenStable();
     spyOn<any>(component['service'], 'submit');
-    const submitButtonHarness = await loader.getHarness(MatButtonHarness.with(
-      {selector: '.submitButton'}))
     const submit = fixture.debugElement.query(By.css('.submitButton')).nativeElement;
 
     submit.click();
     fixture.detectChanges();
-    // await submitButtonHarness.click();
 
     expect(component['service'].submit).toHaveBeenCalled();
   });

--- a/src/app/options/options.component.spec.ts
+++ b/src/app/options/options.component.spec.ts
@@ -20,7 +20,7 @@ describe('OptionsComponent', () => {
   let component: OptionsComponent;
   let fixture: ComponentFixture<OptionsComponent>;
   let loader: HarnessLoader;
-  let mockService: MockSubmitService;
+  let service: MockSubmitService;
   const blankData: OpenBabelData = {inputString: "",
     inputFormat: "", outputFormat: "", additionalOptions: ""};
 
@@ -47,7 +47,7 @@ describe('OptionsComponent', () => {
   async function createState(state: string = ComponentState.BLANK) {
     fixture = TestBed.createComponent(OptionsComponent);
     component = fixture.componentInstance;
-    mockService = TestBed.inject(MockSubmitService);
+    service = TestBed.inject(MockSubmitService);
     component.formats = [ "test1", "test2 [Read-only]", "test3 [Write-only]" ];
     loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
@@ -158,8 +158,6 @@ describe('OptionsComponent', () => {
     await createState();
     const inputError = fixture.debugElement.query(By.css('.input-error'));
     const outputError = fixture.debugElement.query(By.css('.output-error'));
-    expect(component.inputControl.invalid).toEqual(true);
-    expect(component.outputControl.invalid).toEqual(true);
     expect(inputError).toBeTruthy();
     expect(outputError).toBeTruthy();
   });
@@ -167,28 +165,24 @@ describe('OptionsComponent', () => {
   it('should display input mat-error if input form control is invalid', async () => {
     await createState(ComponentState.INVALID_INPUT);
     const inputError = fixture.debugElement.query(By.css('.input-error'));
-    expect(component.inputControl.invalid).toEqual(true);
     expect(inputError).toBeTruthy();
   });
 
   it('should display output mat-error if output form control is invalid', async () => {
     await createState(ComponentState.INVALID_OUTPUT);
     const outputError = fixture.debugElement.query(By.css('.output-error'));
-    expect(component.outputControl.invalid).toEqual(true);
     expect(outputError).toBeTruthy();
   });
 
   it('should not display input mat-error if input form control is valid', async () => {
     await createState(ComponentState.VALID_INPUT);
     const inputError = fixture.debugElement.query(By.css('.input-error'));
-    expect(component.inputControl.invalid).toEqual(false);
     expect(inputError).toBeNull();
   });
 
   it('should not display output mat-error if output form control is valid', async () => {
     await createState(ComponentState.VALID_OUTPUT);
     const outputError = fixture.debugElement.query(By.css('.output-error'));
-    expect(component.outputControl.invalid).toEqual(false);
     expect(outputError).toBeNull();
   });
 
@@ -200,7 +194,7 @@ describe('OptionsComponent', () => {
     await output.focus();
     await output.enterText("Output format");
 
-    component.service.data$.subscribe(
+    service.data$.subscribe(
       data => expect(data['outputFormat']).toEqual("Output format")
     );
   });
@@ -213,7 +207,7 @@ describe('OptionsComponent', () => {
     await input.focus();
     await input.enterText("Input format");
 
-    component.service.data$.subscribe(
+    service.data$.subscribe(
       data => expect(data['inputFormat']).toEqual("Input format")
     );
   });
@@ -223,19 +217,19 @@ describe('OptionsComponent', () => {
     const additionalOptionsHarness = await loader.getHarness(MatInputHarness.with(
       {selector: '.additionalOptions'}));
 
-    component.service.data$.subscribe(
+    service.data$.subscribe(
       data => expect(data['additionalOptions']).toEqual("")
     );
     await additionalOptionsHarness.setValue("Some additional options text");
 
-    component.service.data$.subscribe(
+    service.data$.subscribe(
       data => expect(data['additionalOptions']).toEqual("Some additional options text")
     );
   });
 
   it('should call service.submit when submit button is pressed', async () => {
     await createState();
-    spyOn<any>(component['service'], 'submit').and.returnValue(mockService.submit());
+    spyOn<any>(service, 'submit').and.callThrough();
     const submit = fixture.debugElement.query(By.css('.submitButton')).nativeElement;
 
     submit.disabled = false;
@@ -243,7 +237,7 @@ describe('OptionsComponent', () => {
     dispatchEvent(new Event('click'));
     fixture.detectChanges();
 
-    expect(component['service'].submit).toHaveBeenCalled();
+    expect(service.submit).toHaveBeenCalled();
   });
 
   for (const state of Object.keys(ComponentState)) {

--- a/src/app/options/options.component.spec.ts
+++ b/src/app/options/options.component.spec.ts
@@ -15,6 +15,8 @@ import { tap } from 'rxjs/operators';
 import { OpenBabelData } from '../OpenBabelData';
 import { OptionsComponent } from './options.component';
 import { MockSubmitService } from '../submit.mock.service';
+import { DataService } from '../submit.abstract.service';
+import { SubmitService } from '../submit.service';
 
 describe('OptionsComponent', () => {
   let component: OptionsComponent;
@@ -29,7 +31,7 @@ describe('OptionsComponent', () => {
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
       imports: [ FormsModule, ReactiveFormsModule, MatAutocompleteModule, HttpClientTestingModule ],
       declarations: [ OptionsComponent ],
-      providers: [ MockSubmitService ]
+      providers: [ OptionsComponent, { provide: DataService, useClass: MockSubmitService } ]
     })
     .compileComponents();
   });
@@ -45,9 +47,9 @@ describe('OptionsComponent', () => {
     VALID_OUTPUT: "Valid Output",
   };
   async function createState(state: string = ComponentState.BLANK) {
+    service = TestBed.inject(DataService);
     fixture = TestBed.createComponent(OptionsComponent);
     component = fixture.componentInstance;
-    service = TestBed.inject(MockSubmitService);
     component.formats = [ "test1", "test2 [Read-only]", "test3 [Write-only]" ];
     loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
@@ -80,7 +82,6 @@ describe('OptionsComponent', () => {
         await input.enterText("Invalid input format");
         break;
       case ComponentState.VALID_INPUT:
-        await fixture.whenStable();
         await input.focus();
         await input.enterText("acesout -- ACES output format [Read-only]");
         break;
@@ -112,7 +113,7 @@ describe('OptionsComponent', () => {
     await input.focus();
     let options = await input.getOptions();
 
-    expect(options.length).toEqual(2);
+    expect((await input.getOptions()).length).toEqual(2);
     expect((await options[1].getText())).toEqual("test2 [Read-only]");
   });
 

--- a/src/app/options/options.component.spec.ts
+++ b/src/app/options/options.component.spec.ts
@@ -14,11 +14,13 @@ import { tap } from 'rxjs/operators';
 
 import { OpenBabelData } from '../OpenBabelData';
 import { OptionsComponent } from './options.component';
+import { MockSubmitService } from '../submit.mock.service';
 
 describe('OptionsComponent', () => {
   let component: OptionsComponent;
   let fixture: ComponentFixture<OptionsComponent>;
   let loader: HarnessLoader;
+  let mockService: MockSubmitService;
   const blankData: OpenBabelData = {inputString: "",
     inputFormat: "", outputFormat: "", additionalOptions: ""};
 
@@ -26,30 +28,91 @@ describe('OptionsComponent', () => {
     await TestBed.configureTestingModule({
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
       imports: [ FormsModule, ReactiveFormsModule, MatAutocompleteModule, HttpClientTestingModule ],
-      declarations: [ OptionsComponent ]
+      declarations: [ OptionsComponent ],
+      providers: [ MockSubmitService ]
     })
     .compileComponents();
   });
 
-  beforeEach(() => {
+  const ComponentState = {
+    BLANK: "Blank",
+    VALID: "Valid",
+    SUBMITTING: "Submitting",
+    VALID_AND_SUBMITTING: "Valid and Submitting",
+    INVALID_INPUT: "Invalid Input",
+    VALID_INPUT: "Valid Input",
+    INVALID_OUTPUT: "Invalid Output",
+    VALID_OUTPUT: "Valid Output",
+  };
+  async function createState(state: string = ComponentState.BLANK) {
     fixture = TestBed.createComponent(OptionsComponent);
     component = fixture.componentInstance;
+    mockService = TestBed.inject(MockSubmitService);
     component.formats = [ "test1", "test2 [Read-only]", "test3 [Write-only]" ];
     loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
-  });
+    const input = await loader.getHarness(MatAutocompleteHarness.with({
+      selector: '.inputInput'}));
+    const output = await loader.getHarness(MatAutocompleteHarness.with({
+      selector: '.outputInput'}));
+    switch(state) {
+      case ComponentState.BLANK:
+        break;
+      case ComponentState.VALID:
+        await input.focus();
+        await input.enterText("acesout -- ACES output format [Read-only]");
+        await output.focus();
+        await output.enterText("acesin -- ACES input format [Write-only]");
+        component.submitting$ = of(false);
+        break;
+      case ComponentState.SUBMITTING:
+        component.submitting$ = of(true);
+        break;
+      case ComponentState.VALID_AND_SUBMITTING:
+        await input.focus();
+        await input.enterText("acesout -- ACES output format [Read-only]");
+        await output.focus();
+        await output.enterText("acesin -- ACES input format [Write-only]");
+        component.submitting$ = of(true);
+        break;
+      case ComponentState.INVALID_INPUT:
+        await input.focus();
+        await input.enterText("Invalid input format");
+        break;
+      case ComponentState.VALID_INPUT:
+        await fixture.whenStable();
+        await input.focus();
+        await input.enterText("acesout -- ACES output format [Read-only]");
+        break;
+      case ComponentState.INVALID_OUTPUT:
+        await output.focus();
+        await output.enterText("Invalid output format");
+        break;
+      case ComponentState.VALID_OUTPUT:
+        await output.focus();
+        await output.enterText("acesin -- ACES input format [Write-only]");
+        break;
+      default:
+        console.log("State not found.");
+        break;
+    }
+    fixture.detectChanges();
+  };
 
   it('should create', () => {
+    createState();
     expect(component).toBeTruthy();
   });
 
   it('should filter out write-only results from input drop-down list', async () => {
-    await fixture.whenStable();
+    await createState();
+    spyOn<any>(component, 'inputList').and.callFake(() => of([""]));
     const input = await loader.getHarness(MatAutocompleteHarness.with({
       selector: '.inputInput'}));
 
     await input.focus();
 
+    //expect(spy).toHaveBeenCalledWith("");
     component.inputList.subscribe(
       list => {
         expect(list.length).toEqual(2);
@@ -59,7 +122,7 @@ describe('OptionsComponent', () => {
   });
 
   it('should filter results for input drowdown list based on input', async () => {
-    await fixture.whenStable();
+    await createState();
     const input = await loader.getHarness(MatAutocompleteHarness.with({
       selector: '.inputInput'}));
 
@@ -72,7 +135,7 @@ describe('OptionsComponent', () => {
   });
 
   it('should filter out read-only results from output drop-down list', async () => {
-    await fixture.whenStable();
+    await createState();
     const output = await loader.getHarness(MatAutocompleteHarness.with({
       selector: '.outputInput'}));
 
@@ -87,7 +150,7 @@ describe('OptionsComponent', () => {
   });
 
   it('should filter results for output drowdown list based on input', async () => {
-    await fixture.whenStable();
+    await createState();
     const output = await loader.getHarness(MatAutocompleteHarness.with({
       selector: '.outputInput'}));
 
@@ -99,8 +162,46 @@ describe('OptionsComponent', () => {
     expect((await options[0].getText())).toEqual("test1");
   });
 
+  it('should display mat-errors if input form control is blank', async () => {
+    await createState();
+    const inputError = fixture.debugElement.query(By.css('.input-error'));
+    const outputError = fixture.debugElement.query(By.css('.output-error'));
+    expect(component.inputControl.invalid).toEqual(true);
+    expect(component.outputControl.invalid).toEqual(true);
+    expect(inputError).toBeTruthy();
+    expect(outputError).toBeTruthy();
+  });
+
+  it('should display input mat-error if input form control is invalid', async () => {
+    await createState(ComponentState.INVALID_INPUT);
+    const inputError = fixture.debugElement.query(By.css('.input-error'));
+    expect(component.inputControl.invalid).toEqual(true);
+    expect(inputError).toBeTruthy();
+  });
+
+  it('should display output mat-error if output form control is invalid', async () => {
+    await createState(ComponentState.INVALID_OUTPUT);
+    const outputError = fixture.debugElement.query(By.css('.output-error'));
+    expect(component.outputControl.invalid).toEqual(true);
+    expect(outputError).toBeTruthy();
+  });
+
+  it('should not display input mat-error if input form control is valid', async () => {
+    await createState(ComponentState.VALID_INPUT);
+    const inputError = fixture.debugElement.query(By.css('.input-error'));
+    expect(component.inputControl.invalid).toEqual(false);
+    expect(inputError).toBeNull();
+  });
+
+  it('should not display output mat-error if output form control is valid', async () => {
+    await createState(ComponentState.VALID_OUTPUT);
+    const outputError = fixture.debugElement.query(By.css('.output-error'));
+    expect(component.outputControl.invalid).toEqual(false);
+    expect(outputError).toBeNull();
+  });
+
   it('should update data$ observable from additional options string', async () => {
-    await fixture.whenStable();
+    await createState();
     const additionalOptionsHarness = await loader.getHarness(MatInputHarness.with(
       {selector: '.additionalOptions'}));
 
@@ -115,8 +216,8 @@ describe('OptionsComponent', () => {
   });
 
   it('should call service.submit when submit button is pressed', async () => {
-    await fixture.whenStable();
-    spyOn<any>(component['service'], 'submit');
+    await createState();
+    spyOn<any>(component['service'], 'submit').and.returnValue(mockService.submit());
     const submit = fixture.debugElement.query(By.css('.submitButton')).nativeElement;
 
     submit.disabled = false;
@@ -127,29 +228,20 @@ describe('OptionsComponent', () => {
     expect(component['service'].submit).toHaveBeenCalled();
   });
 
-  it('should update form control based on input', async () => {
-    await fixture.whenStable();
-    const input = await loader.getHarness(MatAutocompleteHarness.with({
-      selector: '.inputInput'}));
-
-    await input.focus();
-    await input.enterText("test1");
-
-    const output = await loader.getHarness(MatAutocompleteHarness.with({
-      selector: '.outputInput'}));
-
-    await output.focus();
-    await output.enterText("test1");
-
-    await input.getOptions();
-    await output.getOptions();
-    fixture.detectChanges();
-    const submit = fixture.debugElement.query(By.css('.submitButton')).nativeElement;
-    expect(submit.disabled).toEqual(false);
-    component.inputList.subscribe(
-      value => {
-        expect(component.inputControl.invalid).toEqual(false);
+  for (const state of Object.keys(ComponentState)) {
+    if (state == "VALID") {
+      it('should enable submit button if formats valid and not submitting', async () => {
+        await createState(ComponentState[state]);
+        const submit = fixture.debugElement.query(By.css('.submitButton')).nativeElement;
         expect(submit.disabled).toEqual(false);
       });
-  });
+    }
+    else {
+      it('should disable submit button in all other states', async () => {
+        await createState(ComponentState[state]);
+        const submit = fixture.debugElement.query(By.css('.submitButton')).nativeElement;
+        expect(submit.disabled).toEqual(true);
+      });
+    }
+  }
 });

--- a/src/app/options/options.component.spec.ts
+++ b/src/app/options/options.component.spec.ts
@@ -8,6 +8,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Observable, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -104,5 +105,19 @@ describe('OptionsComponent', () => {
     await additionalOptionsHarness.setValue("Some additional options text");
 
     expect(data['additionalOptions']).toEqual("Some additional options text");
+  });
+
+  it('should call service.submit when submit button is pressed', async () => {
+    await fixture.whenStable();
+    spyOn<any>(component['service'], 'submit');
+    const submitButtonHarness = await loader.getHarness(MatButtonHarness.with(
+      {selector: '.submitButton'}))
+    const submit = fixture.debugElement.query(By.css('.submitButton')).nativeElement;
+
+    submit.click();
+    fixture.detectChanges();
+    // await submitButtonHarness.click();
+
+    expect(component['service'].submit).toHaveBeenCalled();
   });
 });

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -36,13 +36,13 @@ export class OptionsComponent implements AfterViewInit {
     }),
   );
   additionalOptions: String = this.service.data.additionalOptions;
-  submit$: Observable<boolean> = of(false);
+  submitting$: Observable<boolean> = of(false);
   @ViewChild('submitButton', {read: ElementRef}) submitButton: ElementRef;
 
   constructor(private readonly service: SubmitService) {}
 
   ngAfterViewInit() {
-    this.submit$ = fromEvent(this.submitButton.nativeElement, 'click').pipe(
+    this.submitting$ = fromEvent(this.submitButton.nativeElement, 'click').pipe(
       mergeMap(() => {
         return concat(
           of(true),

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -46,7 +46,7 @@ export class OptionsComponent implements AfterViewInit {
         return concat(
           of(true),
           of(true).pipe(this.service.submit(), mapTo(false))
-        )
+        );
       }), startWith(false)
     );
   }

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -12,7 +12,7 @@ import { SubmitService } from '../submit.service';
   templateUrl: './options.component.html',
   styleUrls: ['./options.component.css']
 })
-export class OptionsComponent implements AfterViewInit{
+export class OptionsComponent implements AfterViewInit {
   formats: String[] = FORMATS;
   data$: Observable<OpenBabelData> = this.service.data$;
   inputControl = new FormControl('', [Validators.required, validateFormat]);

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -5,6 +5,7 @@ import { map, startWith, mergeMap, mapTo, tap } from 'rxjs/operators';
 
 import { OpenBabelData } from '../OpenBabelData';
 import { FORMATS } from '../formatlist';
+import { DataService } from '../submit.abstract.service';
 import { SubmitService } from '../submit.service';
 
 @Component({
@@ -37,7 +38,7 @@ export class OptionsComponent implements AfterViewInit {
   submitting$: Observable<boolean> = of(false);
   @ViewChild('submitButton', {read: ElementRef}) submitButton: ElementRef;
 
-  constructor(readonly service: SubmitService) {}
+  constructor(readonly service: DataService) {}
 
   ngAfterViewInit() {
     this.submitting$ = fromEvent(this.submitButton.nativeElement, 'click').pipe(

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -14,7 +14,6 @@ import { SubmitService } from '../submit.service';
 })
 export class OptionsComponent implements AfterViewInit {
   formats: String[] = FORMATS;
-  data$: Observable<OpenBabelData> = this.service.data$;
   inputControl = new FormControl('', [Validators.required, validateFormat(this.formats)]);
   inputList: Observable<String[]> = this.inputControl.valueChanges.pipe(
     startWith(""),
@@ -38,7 +37,7 @@ export class OptionsComponent implements AfterViewInit {
   submitting$: Observable<boolean> = of(false);
   @ViewChild('submitButton', {read: ElementRef}) submitButton: ElementRef;
 
-  constructor(private readonly service: SubmitService) {}
+  constructor(readonly service: SubmitService) {}
 
   ngAfterViewInit() {
     this.submitting$ = fromEvent(this.submitButton.nativeElement, 'click').pipe(

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -37,7 +37,7 @@ export class OptionsComponent implements AfterViewInit{
   );
   additionalOptions: String = this.service.data.additionalOptions;
   submit$: Observable<boolean> = of(false);
-  @ViewChild('submit', {read: ElementRef}) submitButton: ElementRef;
+  @ViewChild('submitButton', {read: ElementRef}) submitButton: ElementRef;
 
   constructor(private readonly service: SubmitService) {}
 

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -48,8 +48,7 @@ export class OptionsComponent implements AfterViewInit{
           of(true),
           of(true).pipe(
             mergeMap(() => this.service.submit()), mapTo(false)
-          ),
-          of(false)
+          )
         )
       }), startWith(false)
     );

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -35,7 +35,6 @@ export class OptionsComponent implements AfterViewInit {
       });
     }),
   );
-  additionalOptions: String = this.service.data.additionalOptions;
   submitting$: Observable<boolean> = of(false);
   @ViewChild('submitButton', {read: ElementRef}) submitButton: ElementRef;
 
@@ -46,9 +45,7 @@ export class OptionsComponent implements AfterViewInit {
       mergeMap(() => {
         return concat(
           of(true),
-          of(true).pipe(
-            mergeMap(() => this.service.submit()), mapTo(false)
-          )
+          of(true).pipe(this.service.submit(), mapTo(false))
         )
       }), startWith(false)
     );

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -15,7 +15,7 @@ import { SubmitService } from '../submit.service';
 export class OptionsComponent implements AfterViewInit {
   formats: String[] = FORMATS;
   data$: Observable<OpenBabelData> = this.service.data$;
-  inputControl = new FormControl('', [Validators.required, validateFormat]);
+  inputControl = new FormControl('', [Validators.required, validateFormat(this.formats)]);
   inputList: Observable<String[]> = this.inputControl.valueChanges.pipe(
     startWith(""),
     map(value => {
@@ -25,7 +25,7 @@ export class OptionsComponent implements AfterViewInit {
       });
     })
   );
-  outputControl = new FormControl('', [Validators.required, validateFormat]);
+  outputControl = new FormControl('', [Validators.required, validateFormat(this.formats)]);
   outputList: Observable<String[]> = this.outputControl.valueChanges.pipe(
     startWith(""),
     map(value => {
@@ -52,9 +52,11 @@ export class OptionsComponent implements AfterViewInit {
   }
 }
 
-function validateFormat(control: AbstractControl): {[key: string]: any} | null {
-  if (!FORMATS.includes(control.value)) {
-    return {invalidFormat: true};
-  }
-  return null;
+function validateFormat(validFormats: String[]) {
+  return (control: AbstractControl): {[key: string]: any} | null => {
+    if (!validFormats.includes(control.value)) {
+      return {invalidFormat: true};
+    }
+    return null;
+  };
 }

--- a/src/app/output/output.component.html
+++ b/src/app/output/output.component.html
@@ -1,4 +1,4 @@
-<mat-card *ngIf="data$ | async as data">
+<mat-card *ngIf="service.data$ | async as data">
   <mat-card-title>Output</mat-card-title>
   <textarea matInput class="outputTextBox" [(ngModel)]="data.output"></textarea>
 </mat-card>

--- a/src/app/output/output.component.spec.ts
+++ b/src/app/output/output.component.spec.ts
@@ -10,11 +10,14 @@ import { Observable, of } from 'rxjs';
 
 import { OpenBabelData } from '../OpenBabelData';
 import { OutputComponent } from './output.component';
+import { DataService } from '../submit.abstract.service';
+import { MockSubmitService } from '../submit.mock.service';
 
 describe('OutputComponent', () => {
   let component: OutputComponent;
   let fixture: ComponentFixture<OutputComponent>;
   let loader: HarnessLoader;
+  let service: MockSubmitService;
   const mockData: Observable<OpenBabelData> = of({inputString: "CCCCOc1ccccc1",
     inputFormat: "SMI", outputFormat: "MOL", additionalOptions: "--gen2D",
     output: "Some output text"});
@@ -23,12 +26,14 @@ describe('OutputComponent', () => {
     await TestBed.configureTestingModule({
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
       imports: [ FormsModule, HttpClientTestingModule ],
-      declarations: [ OutputComponent ]
+      declarations: [ OutputComponent ],
+      providers: [ OutputComponent, { provide: DataService, useClass: MockSubmitService } ]
     })
     .compileComponents();
   });
 
   beforeEach(() => {
+    service = TestBed.inject(DataService);
     fixture = TestBed.createComponent(OutputComponent);
     component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
@@ -43,7 +48,7 @@ describe('OutputComponent', () => {
     await fixture.whenStable();
     const outputHarness = await loader.getHarness(MatInputHarness.with(
       {selector: '.outputTextBox'}));
-    component.service.data$ = mockData;
+    service.data$ = mockData;
 
     const outputString = await outputHarness.getValue();
 

--- a/src/app/output/output.component.spec.ts
+++ b/src/app/output/output.component.spec.ts
@@ -43,7 +43,7 @@ describe('OutputComponent', () => {
     await fixture.whenStable();
     const outputHarness = await loader.getHarness(MatInputHarness.with(
       {selector: '.outputTextBox'}));
-    component.data$ = mockData;
+    component.service.data$ = mockData;
 
     const outputString = await outputHarness.getValue();
 

--- a/src/app/output/output.component.ts
+++ b/src/app/output/output.component.ts
@@ -10,8 +10,6 @@ import { SubmitService } from '../submit.service';
   styleUrls: ['./output.component.css']
 })
 export class OutputComponent {
-  data$: Observable<OpenBabelData> = this.service.data$;
-
-  constructor(private readonly service: SubmitService) {}
+  constructor(readonly service: SubmitService) {}
 
 }

--- a/src/app/output/output.component.ts
+++ b/src/app/output/output.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { OpenBabelData } from '../OpenBabelData';
-import { SubmitService } from '../submit.service';
+import { DataService } from '../submit.abstract.service';
 
 @Component({
   selector: 'app-output',
@@ -10,6 +10,6 @@ import { SubmitService } from '../submit.service';
   styleUrls: ['./output.component.css']
 })
 export class OutputComponent {
-  constructor(readonly service: SubmitService) {}
+  constructor(readonly service: DataService) {}
 
 }

--- a/src/app/submit.abstract.service.ts
+++ b/src/app/submit.abstract.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of, BehaviorSubject, from, OperatorFunction, pipe } from 'rxjs';
+import { mergeMap, catchError, tap, shareReplay, withLatestFrom } from 'rxjs/operators';
+import { OpenBabelData } from './OpenBabelData';
+
+@Injectable({
+  providedIn: 'root'
+})
+export abstract class DataService {
+  private readonly submitUrl: string = "/submit/";
+  private readonly blankData: OpenBabelData = {inputString: "", inputFormat: "", outputFormat: "",
+    additionalOptions: ""};
+  outputSubject: BehaviorSubject<OpenBabelData> = new BehaviorSubject(this.blankData);
+  data$: Observable<OpenBabelData> = from(this.outputSubject).pipe(
+    shareReplay(1)
+  );
+
+  constructor(readonly http: HttpClient) {}
+
+  getSubmitUrl(): string {
+    return this.submitUrl;
+  }
+  getBlankData(): OpenBabelData {
+    return this.blankData;
+  }
+
+  abstract submit(): OperatorFunction<boolean, any>;
+}

--- a/src/app/submit.abstract.service.ts
+++ b/src/app/submit.abstract.service.ts
@@ -16,7 +16,7 @@ export abstract class DataService {
     shareReplay(1)
   );
 
-  constructor(readonly http: HttpClient) {}
+  constructor() {}
 
   getSubmitUrl(): string {
     return this.submitUrl;

--- a/src/app/submit.mock.service.ts
+++ b/src/app/submit.mock.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
 import { Observable, of, BehaviorSubject, from, OperatorFunction, pipe } from 'rxjs';
 import { mergeMap, catchError, tap, shareReplay, withLatestFrom } from 'rxjs/operators';
 
@@ -11,8 +10,8 @@ import { OpenBabelData } from './OpenBabelData';
 })
 export class MockSubmitService extends DataService {
 
-  constructor(http: HttpClient) {
-    super(http);
+  constructor() {
+    super();
   }
 
 	submit(): OperatorFunction<boolean, any> {

--- a/src/app/submit.mock.service.ts
+++ b/src/app/submit.mock.service.ts
@@ -1,48 +1,30 @@
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of, BehaviorSubject, from, OperatorFunction, pipe } from 'rxjs';
+import { mergeMap, catchError, tap, shareReplay, withLatestFrom } from 'rxjs/operators';
 import { OpenBabelData } from './OpenBabelData';
 
 @Injectable({
   providedIn: 'root'
 })
 export class MockSubmitService {
-  readonly submitUrl: string = "/submit/";
-  data: OpenBabelData = {inputString: "", inputFormat: "", outputFormat: "",
+  private readonly submitUrl: string = "/submit/";
+  private readonly blankData: OpenBabelData = {inputString: "", inputFormat: "", outputFormat: "",
     additionalOptions: ""};
+  outputSubject: BehaviorSubject<OpenBabelData> = new BehaviorSubject(this.blankData);
+  data$: Observable<OpenBabelData> = from(this.outputSubject).pipe(
+    shareReplay(1)
+  );
 
-  constructor() {}
+  constructor(private readonly http: HttpClient) {}
 
-  submit(): Observable<OpenBabelData> {
-    const mockData: Observable<OpenBabelData> = of({inputString: "CCCCOc1ccccc1",
-      inputFormat: "SMI", outputFormat: "MOL", additionalOptions: "--gen2D", output: `
-       OpenBabel02012223112D
-
-       11 11  0  0  0  0  0  0  0  0999 V2000
-          4.3301   -1.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          4.3301   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          3.4641    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          2.5981   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          1.7321   -0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
-          0.8660   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          0.8660   -1.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          0.0000   -2.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-         -0.8660   -1.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-         -0.8660   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-         -0.0000   -0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-        1  2  1  0  0  0  0
-        2  3  1  0  0  0  0
-        3  4  1  0  0  0  0
-        4  5  1  0  0  0  0
-        5  6  1  0  0  0  0
-        6 11  1  0  0  0  0
-        6  7  2  0  0  0  0
-        7  8  1  0  0  0  0
-        8  9  2  0  0  0  0
-        9 10  1  0  0  0  0
-       10 11  2  0  0  0  0
-      M  END
-      `});
-    return mockData;
+  submit(): OperatorFunction<boolean, any> {
+    return pipe(
+      withLatestFrom(this.data$),
+      tap(([_, data]) => {
+        data['output'] = "test obabel output";
+        this.outputSubject.next(data);
+      })
+    );
   }
 }

--- a/src/app/submit.mock.service.ts
+++ b/src/app/submit.mock.service.ts
@@ -2,23 +2,20 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of, BehaviorSubject, from, OperatorFunction, pipe } from 'rxjs';
 import { mergeMap, catchError, tap, shareReplay, withLatestFrom } from 'rxjs/operators';
+
+import { DataService } from './submit.abstract.service';
 import { OpenBabelData } from './OpenBabelData';
 
 @Injectable({
   providedIn: 'root'
 })
-export class MockSubmitService {
-  private readonly submitUrl: string = "/submit/";
-  private readonly blankData: OpenBabelData = {inputString: "", inputFormat: "", outputFormat: "",
-    additionalOptions: ""};
-  outputSubject: BehaviorSubject<OpenBabelData> = new BehaviorSubject(this.blankData);
-  data$: Observable<OpenBabelData> = from(this.outputSubject).pipe(
-    shareReplay(1)
-  );
+export class MockSubmitService extends DataService {
 
-  constructor(private readonly http: HttpClient) {}
+  constructor(http: HttpClient) {
+    super(http);
+  }
 
-  submit(): OperatorFunction<boolean, any> {
+	submit(): OperatorFunction<boolean, any> {
     return pipe(
       withLatestFrom(this.data$),
       tap(([_, data]) => {

--- a/src/app/submit.service.spec.ts
+++ b/src/app/submit.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { Observable } from 'rxjs';
+import { Observable, from, of } from 'rxjs';
 import { first, tap } from 'rxjs/operators';
 
 import { OpenBabelData } from './OpenBabelData';
@@ -21,40 +21,13 @@ describe('MockSubmitService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should return an OpenBabelData observable when submit() is called', async () => {
-    const output = await service.submit().toPromise();
+  it('should update data$ with output data when submit() is called', async () => {
+    await of(true).pipe(service.submit()).toPromise();
 
-    expect(output.inputString).toEqual("CCCCOc1ccccc1");
-    expect(output.inputFormat).toEqual("SMI");
-    expect(output.outputFormat).toEqual("MOL");
-    expect(output.additionalOptions).toEqual("--gen2D");
-    expect(output.output).toEqual(`
-       OpenBabel02012223112D
-
-       11 11  0  0  0  0  0  0  0  0999 V2000
-          4.3301   -1.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          4.3301   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          3.4641    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          2.5981   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          1.7321   -0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
-          0.8660   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          0.8660   -1.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-          0.0000   -2.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-         -0.8660   -1.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-         -0.8660   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-         -0.0000   -0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-        1  2  1  0  0  0  0
-        2  3  1  0  0  0  0
-        3  4  1  0  0  0  0
-        4  5  1  0  0  0  0
-        5  6  1  0  0  0  0
-        6 11  1  0  0  0  0
-        6  7  2  0  0  0  0
-        7  8  1  0  0  0  0
-        8  9  2  0  0  0  0
-        9 10  1  0  0  0  0
-       10 11  2  0  0  0  0
-      M  END
-      `);
+    service.data$.subscribe(
+      value => {
+        expect(value['output']).toEqual("test obabel output");
+      }
+    );
   });
 });

--- a/src/app/submit.service.ts
+++ b/src/app/submit.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of, BehaviorSubject, from, OperatorFunction, pipe } from 'rxjs';
-import { mergeMap, catchError, tap, delay, shareReplay, withLatestFrom } from 'rxjs/operators';
+import { mergeMap, catchError, tap, shareReplay, withLatestFrom } from 'rxjs/operators';
 import { OpenBabelData } from './OpenBabelData';
 
 @Injectable({

--- a/src/app/submit.service.ts
+++ b/src/app/submit.service.ts
@@ -28,6 +28,7 @@ export class SubmitService {
     );
   }
 
+  // Catch any http errors thrown by HttpClient
   private handleError<T>(operation = 'operation', result: T) {
     return (error: any): Observable<T> => {
       console.error(error);

--- a/src/app/submit.service.ts
+++ b/src/app/submit.service.ts
@@ -11,8 +11,8 @@ import { OpenBabelData } from './OpenBabelData';
 })
 export class SubmitService extends DataService {
 
-  constructor(http: HttpClient) {
-    super(http);
+  constructor(private readonly http: HttpClient) {
+    super();
   }
 
   submit(): OperatorFunction<boolean, any> {

--- a/src/app/submit.service.ts
+++ b/src/app/submit.service.ts
@@ -26,8 +26,7 @@ export class SubmitService {
       )),
       catchError(this.handleError<OpenBabelData>('submit', this.blankData))
     );
-
-  constructor(private readonly http: HttpClient) {}
+  }
 
   private handleError<T>(operation = 'operation', result: T) {
     return (error: any): Observable<T> => {

--- a/src/app/submit.service.ts
+++ b/src/app/submit.service.ts
@@ -2,29 +2,26 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of, BehaviorSubject, from, OperatorFunction, pipe } from 'rxjs';
 import { mergeMap, catchError, tap, shareReplay, withLatestFrom } from 'rxjs/operators';
+
+import { DataService } from './submit.abstract.service';
 import { OpenBabelData } from './OpenBabelData';
 
 @Injectable({
   providedIn: 'root'
 })
-export class SubmitService {
-  private readonly submitUrl: string = "/submit/";
-  private readonly blankData: OpenBabelData = {inputString: "", inputFormat: "", outputFormat: "",
-    additionalOptions: ""};
-  outputSubject: BehaviorSubject<OpenBabelData> = new BehaviorSubject(this.blankData);
-  data$: Observable<OpenBabelData> = from(this.outputSubject).pipe(
-    shareReplay(1)
-  );
+export class SubmitService extends DataService {
 
-  constructor(private readonly http: HttpClient) {}
+  constructor(http: HttpClient) {
+    super(http);
+  }
 
   submit(): OperatorFunction<boolean, any> {
     return pipe(
       withLatestFrom(this.data$),
-      mergeMap(([_, data]) => this.http.patch<OpenBabelData>(this.submitUrl, data).pipe(
+      mergeMap(([_, data]) => this.http.patch<OpenBabelData>(this.getSubmitUrl(), data).pipe(
         tap((result) => this.outputSubject.next(result))
       )),
-      catchError(this.handleError<OpenBabelData>('submit', this.blankData))
+      catchError(this.handleError<OpenBabelData>('submit', this.getBlankData()))
     );
   }
 


### PR DESCRIPTION
This PR adds the submit button.
This includes adding the button template element to the options component, using ViewChild, AfterViewInit, and fromEvent to observe click events and disable button while an http request is underway, and adding error handling to the service::submit() so the observable can complete. Note for the new unit test I can't use a button harness because (I believe) the service is private and the actual observable isn't returned. As such I used the fixture element to click submit.
This version can be accessed [here](https://20220203t123031-dot-personal-fa-starter-app.wl.r.appspot.com/client/).

Current UI:
![image](https://user-images.githubusercontent.com/93948143/151992809-63393c95-b74a-4b4b-918d-195b2ae2651e.png)

Unit testing:
![image](https://user-images.githubusercontent.com/93948143/153507770-01aaaebf-f138-4aab-b36b-e9d06d7534d8.png)

